### PR TITLE
feat: add method to execute sql statements

### DIFF
--- a/aurora_term/terminal.py
+++ b/aurora_term/terminal.py
@@ -17,6 +17,14 @@ class Terminal(cmd.Cmd):
             database=self.config.database,
         )
 
+    def default(self, line):
+        try:
+            result = self.aurora.execute(line)
+        except Exception as error:
+            print(str(error))
+        else:
+            print(result)
+
     def do_quit(self, arg):
         """Quit aurora-term."""
         return True

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,4 +1,6 @@
+from io import StringIO
 from unittest import mock
+
 from aurora_term import aurora, config, terminal
 
 
@@ -14,3 +16,30 @@ def test_create_terminal(m_boto3):
 def test_terminal_quit_returns_true(m_boto3):
     term = terminal.Terminal()
     assert term.do_quit('')
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+@mock.patch('aurora_term.terminal.aurora')
+def test_terminal_default_output(m_aurora, m_stdout):
+    expected = '[{\'foo\': \'bar\'}]\n'
+    m_aurora.Aurora.return_value.execute.return_value = [{'foo': 'bar'}]
+    line = 'select * from test'
+    term = terminal.Terminal()
+    term.default(line)
+
+    assert m_stdout.getvalue() == expected
+    m_aurora.Aurora.return_value.execute.assert_called_once_with(line)
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+@mock.patch('aurora_term.terminal.aurora')
+def test_terminal_default_handles_exceptions(m_aurora, m_stdout):
+    msg = 'something went wrong'
+    expected = f'{msg}\n'
+    m_aurora.Aurora.return_value.execute.side_effect = Exception(msg)
+    line = 'select * from test'
+    term = terminal.Terminal()
+    term.default(line)
+
+    assert m_stdout.getvalue() == expected
+    m_aurora.Aurora.return_value.execute.assert_called_once_with(line)


### PR DESCRIPTION
This default method in terminal module executes the inputed line against the database and print its result output.