### PR TITLE
feat: add black configurations to pyproject.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Check Python style
         run: poetry run flake8 aurora_term/ tests/
       - name: Check Python code formatting
-        run: poetry run black -l79 -S --check aurora_term/ tests/
+        run: poetry run black --check aurora_term/ tests/
       - name: Run tests
         run: poetry run pytest -x -p no:warnings --cov=aurora_term/ --cov-report term-missing --cov-fail-under 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ pre-commit = "^1.20"
 pytest = "^3.0"
 pytest-cov = "^2.8"
 
+[tool.black]
+line-length = 79
+target-version = ['py37']
+skip-string-normalization = true
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Black has support to read configurations from `pyproject.toml` files, so instead of passing each parameter in the commando line let's add them in the project configuration file.

This also allows to remove the same parameters from the CI configuration.